### PR TITLE
Fix for the port error on restart of SimpleSmtpServer.

### DIFF
--- a/netDumbster/SimpleSmtpServer.cs
+++ b/netDumbster/SimpleSmtpServer.cs
@@ -9,7 +9,6 @@ namespace netDumbster.smtp
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
     using System.Net;
     using System.Net.Sockets;
     using System.Threading;
@@ -173,6 +172,9 @@ namespace netDumbster.smtp
 
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Any, Port);
             tcpListener = new TcpListener(endPoint);
+            // Fix the problem with the scenario if the server is stopped, and then
+            // restarted with the same port, it will not throw an error.
+            tcpListener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
             tcpListener.Start();
 
             log.DebugFormat("Started Tcp Listener at port {0}", Port);


### PR DESCRIPTION
Added a fix  as described in this issue

https://github.com/cmendible/netDumbster/issues/3

I added the option on TcpListener to set the ReuseAddress to true, so that the when stopping the SimpleSmtpServer, and then restarting it using the same port, it will not throw an error.

This became an issue using xUnit, where each test forced a setup and tear down of resources, and SimpleSmtpServer was failing to start after the first test.
