### PR TITLE
Delayed processing

### DIFF
--- a/netDumbster.Test/TestsBase.cs
+++ b/netDumbster.Test/TestsBase.cs
@@ -277,7 +277,7 @@ namespace netDumbster.Test
         {
             // Arrange
             var port = 50003;
-            var server = SimpleSmtpServer.Start(port, processingDelay);
+            var server = SimpleSmtpServer.Start(port, true, processingDelay);
 
             // Act
             var stopwatch = new Stopwatch();

--- a/netDumbster.Test/TestsBase.cs
+++ b/netDumbster.Test/TestsBase.cs
@@ -273,7 +273,7 @@ namespace netDumbster.Test
         [TestCase(0)]
         [TestCase(5000)]
         [TestCase(10000)]
-        public void GivenAProcessingDelay_WhenProcessingANewMessage_ThenItIsProcessedAfterTheDelayHasElapsed(int processingDelay)
+        public void Send_Email_With_Delayed_Processing(int processingDelay)
         {
             // Arrange
             var port = 50003;

--- a/netDumbster.Test/TestsBase.cs
+++ b/netDumbster.Test/TestsBase.cs
@@ -9,6 +9,7 @@ using System.Text;
 using NUnit.Framework;
 using netDumbster.smtp;
 using netDumbster.smtp.Logging;
+using System.Diagnostics;
 
 namespace netDumbster.Test
 {
@@ -267,6 +268,33 @@ namespace netDumbster.Test
             Assert.Greater(randomPortServer.Configuration.Port, 0);
             randomPortServer.Stop();
         }
+
+        [TestCase(-1)]
+        [TestCase(0)]
+        [TestCase(5000)]
+        [TestCase(10000)]
+        public void GivenAProcessingDelay_WhenProcessingANewMessage_ThenItIsProcessedAfterTheDelayHasElapsed(int processingDelay)
+        {
+            // Arrange
+            var port = 50003;
+            var server = SimpleSmtpServer.Start(port, processingDelay);
+
+            // Act
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            SendMail(false, true, null, port);
+            stopwatch.Stop();
+
+            // Assert
+            var elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
+            Console.WriteLine(string.Format("Server took {0} ms to complete", elapsedMilliseconds));
+
+            Assert.That(elapsedMilliseconds, Is.GreaterThanOrEqualTo(processingDelay));
+
+            // Tidy up
+            server.Stop();
+        }
+
 
         protected void SendMail()
         {

--- a/netDumbster/Configure.cs
+++ b/netDumbster/Configure.cs
@@ -56,6 +56,18 @@ namespace netDumbster.smtp
         }
 
         /// <summary>
+        /// Gets the number of milliseconds to wait before processing a new message.
+        /// </summary>
+        public int ProcessingDelayInMilliseconds
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+
+
+        /// <summary>
         /// Configures this instance.
         /// </summary>
         /// <returns></returns>
@@ -107,6 +119,17 @@ namespace netDumbster.smtp
         public Configuration WithAddress(IPAddress address)
         {
             this.IPAddress = address;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures with a processing delay
+        /// </summary>
+        /// <param name="milliseconds">The (minimum) number of milliseconds by which a new message is delay processing by</param>
+        /// <returns></returns>
+        public Configuration WithProcessingDelay(int milliseconds)
+        {
+            this.ProcessingDelayInMilliseconds = milliseconds;
             return this;
         }
 

--- a/netDumbster/SimpleSmtpServer.cs
+++ b/netDumbster/SimpleSmtpServer.cs
@@ -137,7 +137,21 @@ namespace netDumbster.smtp
         /// <returns></returns>
         public static SimpleSmtpServer Start(int port)
         {
-            return SimpleSmtpServer.Start(Configuration.Configure().WithPort(port));
+            return SimpleSmtpServer.Start(port, 0);
+        }
+
+        /// <summary>
+        /// Starts server listening to the specified port with a simulated delay when processing a new SMTP message.
+        /// </summary>
+        /// <param name="port">The port.</param>
+        /// <param name="processingDelayInMilliseconds">The number of milliseconds to wait before processing a new SMTP message</param>
+        /// <returns></returns>
+        public static SimpleSmtpServer Start(int port, int processingDelayInMilliseconds)
+        {
+            return SimpleSmtpServer.Start(Configuration.Configure()
+                                                       .WithPort(port)
+                                                       .WithProcessingDelay(processingDelayInMilliseconds)
+                                          );
         }
 
         /// <summary>
@@ -253,6 +267,11 @@ namespace netDumbster.smtp
             }
 
             this.log.Debug("Entering Socket Handler.");
+
+            if (this.Configuration.ProcessingDelayInMilliseconds > 0)
+            {
+                Thread.Sleep(this.Configuration.ProcessingDelayInMilliseconds);
+            }
 
             try
             {

--- a/netDumbster/SimpleSmtpServer.cs
+++ b/netDumbster/SimpleSmtpServer.cs
@@ -162,7 +162,19 @@ namespace netDumbster.smtp
         /// <returns></returns>
         public static SimpleSmtpServer Start(int port, bool useMessageStore)
         {
-            return SimpleSmtpServer.Start(Configuration.Configure().WithPort(port).EnableMessageStore(useMessageStore));
+            return SimpleSmtpServer.Start(port, useMessageStore, 0);
+        }
+
+        /// <summary>
+        /// Starts the specified port.
+        /// </summary>
+        /// <param name="port">The port.</param>
+        /// <param name="useMessageStore">if set to <c>true</c> [use message store].</param>
+        /// <param name="processingDelayInMilliseconds">The number of milliseconds to wait before processing a new SMTP message</param>
+        /// <returns></returns>
+        public static SimpleSmtpServer Start(int port, bool useMessageStore, int processingDelayInMilliseconds)
+        {
+            return SimpleSmtpServer.Start(Configuration.Configure().WithPort(port).EnableMessageStore(useMessageStore).WithProcessingDelay(processingDelayInMilliseconds));
         }
 
         internal static SimpleSmtpServer Start(Configuration configuration)


### PR DESCRIPTION
The changes I've added allow the SMTP service to be configured so as to delay the processing of any commands it receives.

This is to allow the testing of applications that might need to simulate communication with a slow SMTP service.