### PR TITLE
Change TcpListener ReuseAddress Option to 1

### DIFF
--- a/netDumbster/SimpleSmtpServer.cs
+++ b/netDumbster/SimpleSmtpServer.cs
@@ -223,7 +223,7 @@ namespace netDumbster.smtp
 
             // Fix the problem with the scenario if the server is stopped, and then
             // restarted with the same port, it will not throw an error.
-            this.tcpListener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            this.tcpListener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
             this.tcpListener.Start();
 
             this.log.DebugFormat("Started Tcp Listener at port {0}", this.Configuration.Port);


### PR DESCRIPTION
Based on this answer:
https://social.msdn.microsoft.com/Forums/en-US/5d755d4a-796c-4906-87a3-d7b40c420c4b/how-to-set-the-reuseaddress-socket-option?forum=netfxnetcom

This was brought up in https://github.com/cmendible/netDumbster/issues/18, and I think it might be the same issue as https://github.com/cmendible/netDumbster/issues/19. 

I am getting errors using netDumbster with MsTest. From what I've seen, the TCP Listener can get stuck open, and will cause timeout errors on subsequent tests runs. In my case, the vstest.executionengine.exe is a long running process, and spawns your test as child processes, but due to this option not being set to one, the TCP connection stays open long after the test run is resolved. Setting the value to 1 should make subsequent test runs not care if something else is listening. 

If you're worried about making this change at a global level, it'd be at least nice to have an overload for StartListening that takes in the TcpListener we want to use.