### PR TITLE
fix: show swallowed exceptions and handle empty MIME header values

### DIFF
--- a/netDumbster.Test/MailKitTests.cs
+++ b/netDumbster.Test/MailKitTests.cs
@@ -47,6 +47,7 @@
             message.To.Add(to);
             message.Subject = "test";
             message.Body = new TextPart("plain") { Text = expectedBody };
+            message.Headers.Add("empty-value", string.Empty);
 
             client.Send(message);
 

--- a/netDumbster/MimeKitExtensions.cs
+++ b/netDumbster/MimeKitExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Extensions
 {
     using System.IO;
@@ -130,7 +132,7 @@ namespace Extensions
             var sender = message.Sender;
 
             foreach (var header in message.Headers)
-                msg.Headers.Add(header.Field, header.Value);
+                msg.Headers.Add(header.Field, string.IsNullOrWhiteSpace(header.Value) ? "<null>" : header.Value);
 
             if (sender != null)
                 msg.Sender = ConvertToMailAddress(sender);

--- a/netDumbster/MimeKitExtensions.cs
+++ b/netDumbster/MimeKitExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Extensions
 {
     using System.IO;
@@ -132,7 +130,10 @@ namespace Extensions
             var sender = message.Sender;
 
             foreach (var header in message.Headers)
-                msg.Headers.Add(header.Field, string.IsNullOrWhiteSpace(header.Value) ? "<null>" : header.Value);
+            {
+                if (string.IsNullOrEmpty(header.Value)) continue;
+                msg.Headers.Add(header.Field, header.Value);
+            }
 
             if (sender != null)
                 msg.Sender = ConvertToMailAddress(sender);

--- a/netDumbster/SmtpProcessor.cs
+++ b/netDumbster/SmtpProcessor.cs
@@ -346,7 +346,7 @@ namespace netDumbster.smtp
                         case "helo":
                             this.Helo(context, inputs);
                             break;
-                        case "ehlo":                           
+                        case "ehlo":
                             context.WriteLine("250-{inputs[1]}");
                             context.WriteLine("250 AUTH PLAIN");
                             context.LastCommand = COMMAND_HELO;
@@ -399,6 +399,11 @@ namespace netDumbster.smtp
                     {
                         context.WriteLine(MESSAGE_GOODBYE);
                     }
+                    else
+                    {
+                        this.log.Error("Processing exception", ex);
+                    }
+
 
                     // else
                     //    context.WriteLine(MESSAGE_SYSTEM_ERROR);


### PR DESCRIPTION
The server silently crashes when trying to parse a header with an empty-string value.

Adding:
- [x] - stop swallowing exceptions
- [x] - add a place holder value for empty-value headers
