### PR TITLE
Added ReplyToAddresses to SmtpMessage

### DIFF
--- a/netDumbster.Test/TestsBase.cs
+++ b/netDumbster.Test/TestsBase.cs
@@ -1,10 +1,9 @@
-﻿using System.Linq;
-
-namespace netDumbster.Test
+﻿namespace netDumbster.Test
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Text;
     using netDumbster.smtp;

--- a/netDumbster.Test/TestsBase.cs
+++ b/netDumbster.Test/TestsBase.cs
@@ -1,4 +1,6 @@
-﻿namespace netDumbster.Test
+﻿using System.Linq;
+
+namespace netDumbster.Test
 {
     using System;
     using System.Collections.Generic;
@@ -40,6 +42,47 @@
         {
             this.SendMail();
             Assert.Equal("test", this.server.ReceivedEmail[0].Subject);
+        }
+
+        [Fact]
+        public void Addresses_Are_Correct()
+        {
+            using (SmtpClient client = new SmtpClient())
+            {
+                client.Connect("localhost", this.server.Configuration.Port, false);
+                var from = new MailboxAddress("from", "carlos@netdumbster.com");
+                var to = new[]
+                {
+                    new MailboxAddress("to-1", "karina@netdumbster.com"),
+                    new MailboxAddress("to-2", "john@netdumbster.com"),
+                };
+                var replyTo = new[]
+                {
+                    new MailboxAddress("replyTo-1", "jane@netdumbster.com"),
+                    new MailboxAddress("replyTo-2", "edward@netdumbster.com"),
+                };
+
+                var message = new MimeMessage();
+
+                message.From.Add(from);
+                message.To.AddRange(to);
+                message.ReplyTo.AddRange(replyTo);
+                message.Subject = "test";
+
+                client.Send(message);
+
+                var receivedMessage = server.ReceivedEmail[0];
+
+                Assert.Equal(receivedMessage.FromAddress.Address, from.Address);
+                Assert.Equal(
+                    receivedMessage.ToAddresses.Select(a => a.Address),
+                    to.Select(a => a.Address)
+                );
+                Assert.Equal(
+                    receivedMessage.ReplyToAddresses.Select(a => a.Address),
+                    replyTo.Select(a => a.Address)
+                );
+            }
         }
 
         [Fact]
@@ -150,9 +193,12 @@
                 builder.TextBody = "this is the body";
                 builder.HtmlBody = "FooBar";
 
-                builder.Attachments.Add("Attachment1", System.Text.Encoding.UTF8.GetBytes("Attachment1"), ContentType.Parse("application/octet-stream"));
-                builder.Attachments.Add("Attachment2", System.Text.Encoding.UTF8.GetBytes("Attachment2"), ContentType.Parse("application/octet-stream"));
-                builder.Attachments.Add("Attachment3", System.Text.Encoding.UTF8.GetBytes("Attachment3"), ContentType.Parse("application/octet-stream"));
+                builder.Attachments.Add("Attachment1", System.Text.Encoding.UTF8.GetBytes("Attachment1"),
+                    ContentType.Parse("application/octet-stream"));
+                builder.Attachments.Add("Attachment2", System.Text.Encoding.UTF8.GetBytes("Attachment2"),
+                    ContentType.Parse("application/octet-stream"));
+                builder.Attachments.Add("Attachment3", System.Text.Encoding.UTF8.GetBytes("Attachment3"),
+                    ContentType.Parse("application/octet-stream"));
 
                 message.Body = builder.ToMessageBody();
 

--- a/netDumbster/SmtpMessage.cs
+++ b/netDumbster/SmtpMessage.cs
@@ -28,7 +28,10 @@ namespace netDumbster.smtp
             {
                 this.Headers = mailMessage.Headers;
                 this.FromAddress = new EmailAddress(mailMessage.From.Address);
-                this.ToAddresses = rawSmtpMessage.Recipients.ToArray();
+                this.ReplyToAddresses = mailMessage.ReplyToList
+                    .Select(m => new EmailAddress(m.Address)).ToArray();
+                this.ToAddresses = mailMessage.To
+                    .Select(m => new EmailAddress(m.Address)).ToArray();
                 this.MessageParts = mailMessage.Parts();
                 this.LocalIPAddress = rawSmtpMessage.LocalIPAddress;
                 this.LocalPort = rawSmtpMessage.LocalPort;
@@ -158,6 +161,16 @@ namespace netDumbster.smtp
         /// delivered to.
         /// </summary>
         public EmailAddress[] ToAddresses
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The addresses that this message will be
+        /// replied to.
+        /// </summary>
+        public EmailAddress[] ReplyToAddresses
         {
             get;
             private set;


### PR DESCRIPTION
I noticed that ReplyTo was not accessible in SmtpMessage. I've added the property and also changed the code for determining the To address to use the same logic.