### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0.html
 
 Create a netDumbster Server instance:
 ````
-var server = SimpleSmtpServer.Start(port);
+using var server = SimpleSmtpServer.Start(port);
 ````
 
 Check received email count:


### PR DESCRIPTION
`SimpleSmtpServer` implements `IDisposable`, so `using` before `var` is required in order the server to be stopped automatically.