### PR TITLE
Allow triggering MessageReceived event even if not using MessageStore

### DIFF
--- a/netDumbster.Test/LoopbackAdapterTests.cs
+++ b/netDumbster.Test/LoopbackAdapterTests.cs
@@ -19,4 +19,20 @@ public class LoopbackAdapterTests : TestsBase
             .Build();
     }
 
+    protected override SimpleSmtpServer StartServer(bool useMessageStore)
+    {
+        return Configuration.Configure()
+            .WithAddress(IPAddress.Loopback)
+            .EnableMessageStore(useMessageStore)
+            .Build();
+    }
+
+    protected override SimpleSmtpServer StartServer(int port, bool useMessageStore)
+    {
+        return Configuration.Configure()
+            .WithAddress(IPAddress.Loopback)
+            .WithPort(port)
+            .EnableMessageStore(useMessageStore)
+            .Build();
+    }
 }

--- a/netDumbster.Test/TestsBase.cs
+++ b/netDumbster.Test/TestsBase.cs
@@ -1,4 +1,6 @@
-﻿namespace netDumbster.Test;
+﻿using System.Threading;
+
+namespace netDumbster.Test;
 
 public class TestsBase : IDisposable
 {
@@ -18,6 +20,16 @@ public class TestsBase : IDisposable
     protected virtual SimpleSmtpServer StartServer(int port)
     {
         return SimpleSmtpServer.Start(port);
+    }
+
+    protected virtual SimpleSmtpServer StartServer(bool useMessageStore)
+    {
+        return SimpleSmtpServer.Start(useMessageStore);
+    }
+
+    protected virtual SimpleSmtpServer StartServer(int port, bool useMessageStore)
+    {
+        return SimpleSmtpServer.Start(port, useMessageStore);
     }
 
     [Fact]
@@ -357,15 +369,17 @@ public class TestsBase : IDisposable
         server.Stop();
     }
 
-    [Fact]
-    public void Send_Fires_Message_Received_Event()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Send_Fires_Message_Received_Event(bool useMessageStore)
     {
         int port = GetRandomUnusedPort();
-        SimpleSmtpServer fixedPortServer = StartServer(port);
+        SimpleSmtpServer fixedPortServer = StartServer(port, useMessageStore);
         fixedPortServer.MessageReceived += (sender, args) =>
         {
             Assert.NotNull(args.Message);
-            Assert.Equal(1, fixedPortServer.ReceivedEmailCount);
+            Assert.Equal(useMessageStore ? 1 : 0, fixedPortServer.ReceivedEmailCount);
             Assert.Equal("this is the body", args.Message.MessageParts[0].BodyData);
         };
 

--- a/netDumbster/SmtpProcessor.cs
+++ b/netDumbster/SmtpProcessor.cs
@@ -189,18 +189,20 @@ public class SmtpProcessor
         }
 
         // Spool the message
-        if (smtpMessageStore is not null)
+        if (smtpMessageStore is not null || MessageReceived is not null)
         {
-            lock (smtpMessageStore)
+            var smtpMessage = new SmtpMessage(rawSmtpMessage);
+
+            if (smtpMessageStore is not null)
             {
-                var smtpMessage = new SmtpMessage(rawSmtpMessage);
-
-                smtpMessageStore.Add(smtpMessage);
-
-                if (MessageReceived is not null)
+                lock (smtpMessageStore)
                 {
-                    MessageReceived(this, new MessageReceivedArgs(smtpMessage));
+                    smtpMessageStore.Add(smtpMessage);
                 }
+            }
+            if (MessageReceived is not null)
+            {
+                MessageReceived(this, new MessageReceivedArgs(smtpMessage));
             }
         }
 


### PR DESCRIPTION
The triggering of MessageReceived event used to happen only if the server has been configured to use MessageStore.
This commit allows processing of messages by an event handler without the need to store them.